### PR TITLE
ページ更新時に一瞬{{　}}が見えるバグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       </div>
 
       <transition appear>
-        <div v-show="show">
+        <div v-show="show" v-cloak>
           <!-- Timer -->
           <div class="timer">
             <span id="minutes">{{ minutes }}</span>


### PR DESCRIPTION
Vue.jsのコンパイルまでの間に一瞬{{　}}が見えるので、v-cloakを追加してcssにてdisplay: none;で削除した。